### PR TITLE
Inline websocket connection 

### DIFF
--- a/server.go
+++ b/server.go
@@ -111,7 +111,7 @@ func (s Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s Server) Serve() {
-	log.Printf("Listening on http://localhost:%d/tera", s.port)
+	log.Printf("Listening on http://localhost:%d", s.port)
 	if err := s.server.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}

--- a/template.go
+++ b/template.go
@@ -18,12 +18,8 @@ type TemplConfig struct {
 
 func generateTemplate(cfg TemplConfig) (io.ReadWriter, error) {
 	wr := new(bytes.Buffer)
-	templ, err := template.ParseFS(fs, "templates/index.templ.html")
-	if err != nil {
-		return nil, err
-	}
 
-	templ, err = templ.ParseFS(fs, "templates/index.templ.js")
+	templ, err := template.ParseFiles("templates/index.templ.js")
 	if err != nil {
 		return nil, err
 	}

--- a/template.go
+++ b/template.go
@@ -19,7 +19,7 @@ type TemplConfig struct {
 func generateTemplate(cfg TemplConfig) (io.ReadWriter, error) {
 	wr := new(bytes.Buffer)
 
-	templ, err := template.ParseFiles("templates/index.templ.js")
+	templ, err := template.ParseFS(fs, "templates/index.templ.js")
 	if err != nil {
 		return nil, err
 	}

--- a/templates/index.templ.html
+++ b/templates/index.templ.html
@@ -1,8 +1,0 @@
-<!doctype html>
-<html>
-  <body>
-    <script>
-      {{template "script" .}}
-    </script>
-  </body>
-</html>

--- a/templates/index.templ.js
+++ b/templates/index.templ.js
@@ -1,5 +1,3 @@
-// {{define "script"}}
-
 // add websocket handlers
 const ws = new WebSocket("{{.Uri}}");
 
@@ -75,5 +73,3 @@ async function loadEntryPoint() {
 }
 
 loadEntryPoint();
-
-// {{end}}

--- a/templates/index.templ.js
+++ b/templates/index.templ.js
@@ -1,17 +1,17 @@
 // add websocket handlers
-const ws = new WebSocket("{{.Uri}}");
+const teraWebSocket = new WebSocket("{{.Uri}}");
 
-ws.addEventListener("open", () => {
+teraWebSocket.addEventListener("open", () => {
   console.log("Websocket connection established!");
 });
 
-ws.addEventListener("close", () => {
+teraWebSocket.addEventListener("close", () => {
   console.log("Websocket connection terminated!");
   const html = document.querySelector("html");
   html.innerHTML = "<p> Connection terminated!</p>";
 });
 
-ws.addEventListener("message", async (e) => {
+teraWebSocket.addEventListener("message", async (e) => {
   const event = JSON.parse(e.data);
   reload(event);
 });
@@ -22,7 +22,7 @@ function reload(event) {
 
   // if entrypoint changes, reload the entire page
   if (url == "{{.Entrypoint}}") {
-    loadEntryPoint();
+    location.reload();
     return;
   }
 
@@ -43,33 +43,3 @@ function renderUpdates(tag, url) {
 function stamp(url) {
   return `${url}?t=${new Date().getTime()}`;
 }
-
-// initial data fetch
-async function loadEntryPoint() {
-  const entryPoint = "{{.Entrypoint}}";
-  const html = document.querySelector("html");
-
-  let data;
-  // handle html content
-
-  if (entryPoint.endsWith(".pdf")) {
-    data = `
-      <object 
-        data="${stamp(entryPoint)}" 
-        type="application/pdf" 
-        style="width: 100vw; height: 100vh; position: fixed; top: 0; left: 0; border: none;"
-      >
-      </object>
-    `;
-  } else if (entryPoint.endsWith(".png") || entryPoint.endsWith(".jpg")) {
-    data = `
-      <img src="${stamp(entryPoint)}" style="display: block; margin: 0 auto;" alt="Centered image">
-    `;
-  } else {
-    const resp = await fetch("{{.Entrypoint}}");
-    data = await resp.text();
-  }
-  html.innerHTML = data;
-}
-
-loadEntryPoint();

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func injectLink(html []byte) []byte {
+	script := "<script src='/tera'></script>"
+	inject := fmt.Sprintf("<head>%v</head>", script)
+	return []byte(inject + string(html))
+}


### PR DESCRIPTION
Currently, websocket connection is handled on a separate URI. This causes issues when issues loading Javascript assets under the Same-Origin browser policy.

To circumvent this issue, the websocket script is now injected into the entrypoint file. All asset requests are handled by the http file server. The websocket is only response for notifying the browser of changes.